### PR TITLE
fix: set events to nil in flush function

### DIFF
--- a/amplitude_client.go
+++ b/amplitude_client.go
@@ -90,6 +90,8 @@ func (c *Client) Flush() error {
 		break
 	}
 
+	c.events = nil
+
 	return nil
 }
 

--- a/amplitude_client_test.go
+++ b/amplitude_client_test.go
@@ -31,6 +31,7 @@ func TestClient_AmplitudeClient(t *testing.T) {
 
 	err := client.Flush()
 	c.NoError(err)
+	c.Len(client.events, 0)
 }
 
 func TestClient_AmplitudeClientError(t *testing.T) {


### PR DESCRIPTION
Set events to nil in flush function to be able to use the same isntance multiple times